### PR TITLE
Implement simple exam browser app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # exam_browser
 
-A new Flutter project.
+Simple exam browser built with Flutter. The app allows students to enter a URL
+for their exam and opens it in a full screen WebView. The device is locked into
+the application until the exit button in the top bar is pressed.
 
 ## Getting Started
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="exam_browser"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/kotlin/com/example/exam_browser/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/exam_browser/MainActivity.kt
@@ -1,5 +1,32 @@
 package com.example.exam_browser
 
+import android.os.Build
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val channel = "exam_browser/locktask"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channel).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "startLockTask" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        startLockTask()
+                    }
+                    result.success(null)
+                }
+                "stopLockTask" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        stopLockTask()
+                    }
+                    result.success(null)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+}

--- a/lib/lock_task.dart
+++ b/lib/lock_task.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/services.dart';
+
+class LockTask {
+  static const _channel = MethodChannel('exam_browser/locktask');
+
+  static Future<void> start() async {
+    try {
+      await _channel.invokeMethod('startLockTask');
+    } catch (_) {}
+  }
+
+  static Future<void> stop() async {
+    try {
+      await _channel.invokeMethod('stopLockTask');
+    } catch (_) {}
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,121 @@
 import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'lock_task.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const ExamBrowserApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class ExamBrowserApp extends StatelessWidget {
+  const ExamBrowserApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Exam Browser',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+        colorSchemeSeed: Colors.deepPurple,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const UrlInputPage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+class UrlInputPage extends StatefulWidget {
+  const UrlInputPage({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<UrlInputPage> createState() => _UrlInputPageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _UrlInputPageState extends State<UrlInputPage> {
+  final TextEditingController _controller = TextEditingController();
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
+  void _open() {
+    final raw = _controller.text.trim();
+    if (raw.isEmpty) return;
+    final url = raw.startsWith('http') ? raw : 'https://$raw';
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => BrowserPage(url: url)),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
+      appBar: AppBar(title: const Text('Exam Browser')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
         child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
           mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(
+                labelText: 'Exam URL',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.url,
+              onSubmitted: (_) => _open(),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _open,
+              child: const Text('Start Exam'),
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}
+
+class BrowserPage extends StatefulWidget {
+  const BrowserPage({super.key, required this.url});
+
+  final String url;
+
+  @override
+  State<BrowserPage> createState() => _BrowserPageState();
+}
+
+class _BrowserPageState extends State<BrowserPage> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse(widget.url));
+    LockTask.start();
+  }
+
+  @override
+  void dispose() {
+    LockTask.stop();
+    super.dispose();
+  }
+
+  void _exit() {
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.url),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.exit_to_app),
+            onPressed: _exit,
+          ),
+        ],
+      ),
+      body: WebViewWidget(controller: _controller),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  webview_flutter: ^4.4.2
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- add webview_flutter and create lock task API
- build exam browser UI with URL input and WebView
- lock the task when WebView opens and provide exit button
- expose native implementation for lock task in MainActivity
- allow cleartext traffic
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b717d2d94832487aea96f8fdc90a0